### PR TITLE
add ics cleanup config option

### DIFF
--- a/config.json.example
+++ b/config.json.example
@@ -51,6 +51,19 @@
           "Qualifying": "⏱️",
           "Grand Prix": "🏆"
         }
+      },
+      {
+        "url": "https://data.fis-ski.com/services/public/icalendar-feed-fis-events.html?seasoncode=2026&sectorcode=AL&categorycode=WC&gendercode=M",
+        "uid_prefix": "FISm-",
+        "emoji_mapping": {
+          "default": "⛷️ "
+        },
+        "cleanup_regex": [
+          {
+            "pattern": "STATUS:FREE",
+            "replacement": "STATUS:CONFIRMED"
+          }
+        ],
       }
     ]
   }

--- a/src/utils.py
+++ b/src/utils.py
@@ -163,8 +163,14 @@ def import_ics_feed(calendar, feed_config, uid_prefix, existing_uids, config=Non
     response = requests.get(url)
     response.raise_for_status()
 
+    ics_data = response.content.decode("utf-8")
+    for rule in feed_config.get("cleanup_regex", []):
+        pattern = rule["pattern"]
+        replacement = rule["replacement"]
+        ics_data = re.sub(pattern, replacement, ics_data)
+
     try:
-        cal = Calendar(response.content.decode("utf-8"))
+        cal = Calendar(ics_data)
     except UnicodeDecodeError:
         logger.warning("⚠️ UTF-8 decode failed, falling back to ISO-8859-1")
         cal = Calendar(response.content.decode("iso-8859-1"))


### PR DESCRIPTION
Some ics files come with invalid formatting that the ics library does not allow. This commit adds a config option to define one or more regex rules for replacing potantially breaking parts of the ics.

Also add example usage with such a broken feed in the config.json.example file.

Seeing as you seem Austrian you might actually care about the FIS calendars as well. 