### PR TITLE
added default reminders for ICS feeds

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,8 @@ Example config:
       "emoji_mapping": {
         "Papier": "♻️",
         "default": "📦"
-      }
+      },
+      "default_reminder": "1d"
     }
   ]
 }


### PR DESCRIPTION
This PR adds the functionality to add a default reminder offset to the ics feeds config. The supported units are d for days, h for hours and m for minutes. For example:
"default_reminder": "1d" adds a reminder 1 day before the event starts if the ics feed did not specify a reminder